### PR TITLE
teleports the player back to the kitchen

### DIFF
--- a/Assets/Scenes/Easy.unity
+++ b/Assets/Scenes/Easy.unity
@@ -14716,6 +14716,37 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 624776752457136990, guid: e883ef9085352484c9e3e76351515178, type: 3}
   m_PrefabInstance: {fileID: 482309203}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1877121681
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1877121682}
+  m_Layer: 0
+  m_Name: Level1SpawnPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1877121682
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1877121681}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1878985915 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 7517969456916051927, guid: c564c8c0d0cdc45429417f315e9f3e41, type: 3}
@@ -15484,6 +15515,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   pickup: {fileID: 8300000, guid: 5238e367893684ccd855a6b590768e19, type: 3}
+--- !u!114 &1917347432
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1917347415}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d6fff19c320be4210b19aa8f1c81e282, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  level1SpawnPoint: {fileID: 1877121682}
+  fallThreshold: -15
 --- !u!4 &1927236404 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 400000, guid: fc007040ddf56d841ad2083f918a0924, type: 3}

--- a/Assets/Scripts/Player/PlayerFallHandler.cs
+++ b/Assets/Scripts/Player/PlayerFallHandler.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PlayerFallHandler : MonoBehaviour
+{
+    public Transform level1SpawnPoint;  // Reference to the Level 1 spawn point
+    public float fallThreshold = -10f;  // Y-coordinate threshold to detect falling
+
+    void Update()
+    {
+        // Check if the player has fallen below the threshold
+        if (transform.position.y < fallThreshold)
+        {
+            TeleportToLevel1();  // Teleport the player back to the spawn point
+        }
+    }
+
+    void TeleportToLevel1()
+    {
+        // Move the player to the spawn point's position
+        transform.position = level1SpawnPoint.position;
+    }
+}

--- a/Assets/Scripts/Player/PlayerFallHandler.cs.meta
+++ b/Assets/Scripts/Player/PlayerFallHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d6fff19c320be4210b19aa8f1c81e282
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Teleports the player back to level 1 when the player falls from a plane

## Description

I make this PR because I added a script to teleport the player back to the kitchen when he falls from any plane

## Type of change

Please delete options that are not relevant.

- [ ] New feature


## Checklist:

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation. If not, please describe your changes!
- [ ] **I have merged this feature/fix to the latest `main` branch on my local machine and does not break other features.**
**[DO NOT CHECK IF NOT]**
