### PR TITLE
adjusted fall thresholds and npc waiting thresholds

### DIFF
--- a/Assets/Scenes/Easy.unity
+++ b/Assets/Scenes/Easy.unity
@@ -6478,7 +6478,7 @@ PrefabInstance:
       objectReference: {fileID: 8300000, guid: e6833e1f5b31e420db02deec6c38a418, type: 3}
     - target: {fileID: 2627469339388657181, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
       propertyPath: frustrationThreshold
-      value: 15
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 2627469339388657181, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
       propertyPath: greetingSounds.Array.size
@@ -19716,8 +19716,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d6fff19c320be4210b19aa8f1c81e282, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  level1SpawnPoint: {fileID: 1877121682}
-  fallThreshold: 0
+  PlayerSpawnPoint: {fileID: 1877121682}
+  fallThreshold: -5
 --- !u!114 &1374779125
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -28472,8 +28472,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d6fff19c320be4210b19aa8f1c81e282, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  level1SpawnPoint: {fileID: 1877121682}
-  fallThreshold: 0
+  PlayerSpawnPoint: {fileID: 1877121682}
+  fallThreshold: -5
 --- !u!4 &1917347434 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 4684403152539725594, guid: c564c8c0d0cdc45429417f315e9f3e41, type: 3}
@@ -33065,7 +33065,7 @@ PrefabInstance:
       objectReference: {fileID: 8300000, guid: e6833e1f5b31e420db02deec6c38a418, type: 3}
     - target: {fileID: 5662483784388613884, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
       propertyPath: frustrationThreshold
-      value: 10
+      value: 40
       objectReference: {fileID: 0}
     - target: {fileID: 5662483784388613884, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
       propertyPath: greetingSounds.Array.size

--- a/Assets/Scenes/Hard.unity
+++ b/Assets/Scenes/Hard.unity
@@ -4682,6 +4682,26 @@ PrefabInstance:
       propertyPath: orderSystem
       value: 
       objectReference: {fileID: 1032051539}
+    - target: {fileID: 2627469339388657181, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
+      propertyPath: frustrationSound
+      value: 
+      objectReference: {fileID: 8300000, guid: e6833e1f5b31e420db02deec6c38a418, type: 3}
+    - target: {fileID: 2627469339388657181, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
+      propertyPath: frustrationThreshold
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627469339388657181, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
+      propertyPath: greetingSounds.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627469339388657181, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
+      propertyPath: greetingSounds.Array.data[0]
+      value: 
+      objectReference: {fileID: 8300000, guid: d21c9762989d943e2b802decbff91977, type: 3}
+    - target: {fileID: 2627469339388657181, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
+      propertyPath: greetingSounds.Array.data[1]
+      value: 
+      objectReference: {fileID: 8300000, guid: 4c3e7d01c04cf48b982f8afc7ca1bf5f, type: 3}
     - target: {fileID: 4598872732503981410, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.7079157
@@ -11399,8 +11419,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d6fff19c320be4210b19aa8f1c81e282, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  level1SpawnPoint: {fileID: 0}
-  fallThreshold: 0
+  PlayerSpawnPoint: {fileID: 1877121682}
+  fallThreshold: -5
 --- !u!114 &1076291617
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -11492,16 +11512,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a44c7540e8ce146b39dee7b57cc9eee5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  boxCastSize: {x: 1, y: 2, z: 0.2}
-  extPos: {x: 0, y: 1.2, z: 0}
   holdPosition: {fileID: 303523125}
   isHoldingIngredients: 0
   HoldingObject: {fileID: 1868824651}
   cookingLayerMask:
     serializedVersion: 2
     m_Bits: 128
-  maxDistanceCookingLM: 1.5
-  indicatorText: {fileID: 1774301301}
 --- !u!82 &1076291622
 AudioSource:
   m_ObjectHideFlags: 0
@@ -12345,6 +12361,102 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6664721575270596811, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
   m_PrefabInstance: {fileID: 418653461}
   m_PrefabAsset: {fileID: 0}
+--- !u!82 &1140013880
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1140013878}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1001 &1142872286
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -18019,8 +18131,6 @@ MonoBehaviour:
   minimumCollisionOffset: 0.2
   cameraCollisionRadius: 2
   cameraFollowSpeed: 0.2
-  cameraLookSpeed: 2
-  cameraPivotSpeed: 2
   camLookSmoothTime: 1
   lookAngle: 0
   pivotAngle: 0
@@ -19589,16 +19699,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a44c7540e8ce146b39dee7b57cc9eee5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  boxCastSize: {x: 1, y: 2, z: 0.2}
-  extPos: {x: 0, y: 1.2, z: 0}
   holdPosition: {fileID: 188891976}
   isHoldingIngredients: 0
   HoldingObject: {fileID: 1501363797}
   cookingLayerMask:
     serializedVersion: 2
     m_Bits: 128
-  maxDistanceCookingLM: 1.5
-  indicatorText: {fileID: 1774301301}
 --- !u!114 &1574412731
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -19690,8 +19796,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d6fff19c320be4210b19aa8f1c81e282, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  level1SpawnPoint: {fileID: 0}
-  fallThreshold: 0
+  PlayerSpawnPoint: {fileID: 1877121682}
+  fallThreshold: -5
 --- !u!114 &1574412736
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -23505,7 +23611,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1877121682}
   m_Layer: 0
-  m_Name: Level1SpawnPoint
+  m_Name: PlayerSpawnPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -26381,6 +26487,102 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 3641730082375272311, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
   m_PrefabInstance: {fileID: 4488804491280236969}
   m_PrefabAsset: {fileID: 0}
+--- !u!82 &919132149208762079
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919132149208762078}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1001 &1025019949591320162
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -27078,6 +27280,22 @@ PrefabInstance:
       propertyPath: orderSystem
       value: 
       objectReference: {fileID: 1032051539}
+    - target: {fileID: 5662483784388613884, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
+      propertyPath: frustrationSound
+      value: 
+      objectReference: {fileID: 8300000, guid: e6833e1f5b31e420db02deec6c38a418, type: 3}
+    - target: {fileID: 5662483784388613884, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
+      propertyPath: greetingSounds.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5662483784388613884, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
+      propertyPath: greetingSounds.Array.data[0]
+      value: 
+      objectReference: {fileID: 8300000, guid: 4c3e7d01c04cf48b982f8afc7ca1bf5f, type: 3}
+    - target: {fileID: 5662483784388613884, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
+      propertyPath: greetingSounds.Array.data[1]
+      value: 
+      objectReference: {fileID: 8300000, guid: d21c9762989d943e2b802decbff91977, type: 3}
     - target: {fileID: 5896881313678767369, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.9999844

--- a/Assets/Scenes/Medium.unity
+++ b/Assets/Scenes/Medium.unity
@@ -4931,6 +4931,26 @@ PrefabInstance:
       propertyPath: orderSystem
       value: 
       objectReference: {fileID: 1032051539}
+    - target: {fileID: 2627469339388657181, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
+      propertyPath: frustrationSound
+      value: 
+      objectReference: {fileID: 8300000, guid: e6833e1f5b31e420db02deec6c38a418, type: 3}
+    - target: {fileID: 2627469339388657181, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
+      propertyPath: frustrationThreshold
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627469339388657181, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
+      propertyPath: greetingSounds.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2627469339388657181, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
+      propertyPath: greetingSounds.Array.data[0]
+      value: 
+      objectReference: {fileID: 8300000, guid: 4c3e7d01c04cf48b982f8afc7ca1bf5f, type: 3}
+    - target: {fileID: 2627469339388657181, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
+      propertyPath: greetingSounds.Array.data[1]
+      value: 
+      objectReference: {fileID: 8300000, guid: d21c9762989d943e2b802decbff91977, type: 3}
     - target: {fileID: 4598872732503981410, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.7079157
@@ -7612,7 +7632,6 @@ MonoBehaviour:
   cookingLayerMask:
     serializedVersion: 2
     m_Bits: 128
-  indicatorText: {fileID: 412877983}
 --- !u!114 &645955743
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7704,8 +7723,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d6fff19c320be4210b19aa8f1c81e282, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  level1SpawnPoint: {fileID: 0}
-  fallThreshold: 0
+  PlayerSpawnPoint: {fileID: 1877121682}
+  fallThreshold: -5
 --- !u!114 &645955748
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10756,7 +10775,7 @@ AudioSource:
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 0}
   m_PlayOnAwake: 0
-  m_Volume: 1
+  m_Volume: 0.15
   m_Pitch: 1
   Loop: 0
   Mute: 0
@@ -12744,6 +12763,102 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6664721575270596811, guid: 6f6bb14c4397544549caeef160af84d5, type: 3}
   m_PrefabInstance: {fileID: 418653461}
   m_PrefabAsset: {fileID: 0}
+--- !u!82 &1140013880
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1140013878}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!4 &1141563612 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 6923265999431268864, guid: d3ccb644b5c1741afaa98bdd36b5ec3c, type: 3}
@@ -16800,7 +16915,7 @@ AudioSource:
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: 5238e367893684ccd855a6b590768e19, type: 3}
-  m_PlayOnAwake: 1
+  m_PlayOnAwake: 0
   m_Volume: 1
   m_Pitch: 1
   Loop: 0
@@ -19154,7 +19269,7 @@ AudioSource:
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: f6275c6f4c4c2497da64d42a8cd5dd59, type: 3}
-  m_PlayOnAwake: 1
+  m_PlayOnAwake: 0
   m_Volume: 1
   m_Pitch: 1
   Loop: 0
@@ -23565,8 +23680,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d6fff19c320be4210b19aa8f1c81e282, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  level1SpawnPoint: {fileID: 0}
-  fallThreshold: 0
+  PlayerSpawnPoint: {fileID: 1877121682}
+  fallThreshold: -5
 --- !u!114 &1824437525
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -23664,7 +23779,6 @@ MonoBehaviour:
   cookingLayerMask:
     serializedVersion: 2
     m_Bits: 128
-  indicatorText: {fileID: 412877983}
 --- !u!82 &1824437530
 AudioSource:
   m_ObjectHideFlags: 0
@@ -24193,7 +24307,7 @@ AudioSource:
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 0}
   m_audioClip: {fileID: 8300000, guid: eea6a5e3e46a54f188e103a0f928fec6, type: 3}
-  m_PlayOnAwake: 1
+  m_PlayOnAwake: 0
   m_Volume: 1
   m_Pitch: 1
   Loop: 0
@@ -24288,7 +24402,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1877121682}
   m_Layer: 0
-  m_Name: Level1SpawnPoint
+  m_Name: PlayerSpawnPoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -26778,6 +26892,102 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 3641730082375272311, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
   m_PrefabInstance: {fileID: 4488804491280236969}
   m_PrefabAsset: {fileID: 0}
+--- !u!82 &919132149208762079
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 919132149208762078}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1001 &1025019949591320162
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -27475,6 +27685,26 @@ PrefabInstance:
       propertyPath: orderSystem
       value: 
       objectReference: {fileID: 1032051539}
+    - target: {fileID: 5662483784388613884, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
+      propertyPath: frustrationSound
+      value: 
+      objectReference: {fileID: 8300000, guid: e6833e1f5b31e420db02deec6c38a418, type: 3}
+    - target: {fileID: 5662483784388613884, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
+      propertyPath: frustrationThreshold
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 5662483784388613884, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
+      propertyPath: greetingSounds.Array.size
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5662483784388613884, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
+      propertyPath: greetingSounds.Array.data[0]
+      value: 
+      objectReference: {fileID: 8300000, guid: 4c3e7d01c04cf48b982f8afc7ca1bf5f, type: 3}
+    - target: {fileID: 5662483784388613884, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
+      propertyPath: greetingSounds.Array.data[1]
+      value: 
+      objectReference: {fileID: 8300000, guid: d21c9762989d943e2b802decbff91977, type: 3}
     - target: {fileID: 5896881313678767369, guid: 5e5f147d4e322484283a85b1d832881f, type: 3}
       propertyPath: m_LocalRotation.w
       value: 0.9999844

--- a/Assets/Scripts/Player/PlayerFallHandler.cs
+++ b/Assets/Scripts/Player/PlayerFallHandler.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 public class PlayerFallHandler : MonoBehaviour
 {
-    public Transform level1SpawnPoint;  // Reference to the Level 1 spawn point
+    public Transform PlayerSpawnPoint;  // Reference to the Level 1 spawn point
     public float fallThreshold = -10f;  // Y-coordinate threshold to detect falling
     private Timer timer;
 
@@ -28,7 +28,7 @@ public class PlayerFallHandler : MonoBehaviour
     void TeleportToLevel1()
     {
         // Move the player to the spawn point's position
-        transform.position = level1SpawnPoint.position;
+        transform.position = PlayerSpawnPoint.position;
     }
 
     void RemoveHoldingObject() {


### PR DESCRIPTION
## Description

I make this PR because I readjusted fall thresholds to -5 and attached the same player spawn point for all levels, and I set the frustration threshold for the npcs (rabbit:40s, horse:50s)
I also set the volume of background music to 0.15 for easy and medium levels.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix


## Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have made corresponding changes to the documentation. If not, please describe your changes!
- [ ] **I have merged this feature/fix to the latest `main` branch on my local machine and does not break other features.**
**[DO NOT CHECK IF NOT]**
this is where you can edit the fall threshold and spawnpoint
<img width="344" alt="Screenshot 2024-11-23 at 4 18 10 PM" src="https://github.com/user-attachments/assets/15dddf9f-ddd0-4a35-85e8-4c99a4448a3e">
this is where you can edit frustration threshold for the npcs:
<img width="345" alt="Screenshot 2024-11-23 at 4 18 36 PM" src="https://github.com/user-attachments/assets/6e9aae99-38c6-481d-96c4-738c4b8b96c3">

